### PR TITLE
Fix lodash dependency issue

### DIFF
--- a/dist/components/Usage/index.js
+++ b/dist/components/Usage/index.js
@@ -1,0 +1,59 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+var _style = require("./style");
+
+var _style2 = _interopRequireDefault(_style);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Usage = function (_Component) {
+  _inherits(Usage, _Component);
+
+  function Usage() {
+    _classCallCheck(this, Usage);
+
+    return _possibleConstructorReturn(this, (Usage.__proto__ || Object.getPrototypeOf(Usage)).apply(this, arguments));
+  }
+
+  _createClass(Usage, [{
+    key: "render",
+    value: function render() {
+      var storySource = this.props.storySource;
+
+      return _react2.default.createElement(
+        "div",
+        { style: _style2.default.wrapper },
+        storySource.split('\n').map(function (item, idx) {
+          var tab = idx > 0 ? _style2.default.tab : null;
+          return _react2.default.createElement(
+            "span",
+            { style: tab, key: idx },
+            item,
+            " ",
+            _react2.default.createElement("br", null)
+          );
+        })
+      );
+    }
+  }]);
+
+  return Usage;
+}(_react.Component);
+
+exports.default = Usage;

--- a/dist/components/Usage/style.js
+++ b/dist/components/Usage/style.js
@@ -1,0 +1,25 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+    value: true
+});
+exports.default = {
+    wrapper: {
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        fontFamily: '-apple-system, ".SFNSText-Regular", "San Francisco", Roboto, "Segoe UI", "Helvetica Neue", "Lucida Grande", sans-serif',
+        color: 'rgb(68, 68, 68)',
+        fontSize: 12,
+        letterSpacing: 1,
+        textDecoration: 'none',
+        listStyleType: 'none',
+        backgroundColor: 'rgb(250, 250, 250)',
+        padding: '10px',
+        margin: '10px'
+    },
+    tab: {
+        marginLeft: '55px'
+    }
+
+};

--- a/dist/containers/Usage/index.js
+++ b/dist/containers/Usage/index.js
@@ -1,0 +1,70 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+var _Usage = require("../../components/Usage/");
+
+var _Usage2 = _interopRequireDefault(_Usage);
+
+var _ = require("../../");
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var Usage = function (_Component) {
+  _inherits(Usage, _Component);
+
+  function Usage(props) {
+    var _ref;
+
+    _classCallCheck(this, Usage);
+
+    for (var _len = arguments.length, args = Array(_len > 1 ? _len - 1 : 0), _key = 1; _key < _len; _key++) {
+      args[_key - 1] = arguments[_key];
+    }
+
+    var _this = _possibleConstructorReturn(this, (_ref = Usage.__proto__ || Object.getPrototypeOf(Usage)).call.apply(_ref, [this, props].concat(args)));
+
+    _this.state = { storybook: "" };
+    _this._listener = function (d) {
+      _this.setState({ storybook: d.storybook });
+    };
+
+    return _this;
+  }
+
+  _createClass(Usage, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      this.props.channel.on(_.EVENT_ID, this._listener);
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      this.props.channel.removeListener(_.EVENT_ID, this._listener);
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var storybook = this.state.storybook;
+      return _react2.default.createElement(_Usage2.default, { storySource: storybook });
+    }
+  }]);
+
+  return Usage;
+}(_react.Component);
+
+exports.default = Usage;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,27 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _manager = require('./manager');
+
+Object.defineProperty(exports, 'register', {
+  enumerable: true,
+  get: function get() {
+    return _manager.register;
+  }
+});
+
+var _preview = require('./preview');
+
+Object.defineProperty(exports, 'Usage', {
+  enumerable: true,
+  get: function get() {
+    return _preview.Usage;
+  }
+});
+// addons, panels and events get unique names using a prefix
+var ADDON_ID = exports.ADDON_ID = 'storybook-addon-usage';
+var PANEL_ID = exports.PANEL_ID = ADDON_ID + '/usage-panel';
+var EVENT_ID = exports.EVENT_ID = ADDON_ID + '/usage-event';

--- a/dist/manager.js
+++ b/dist/manager.js
@@ -1,0 +1,43 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.register = register;
+
+var _react = require('react');
+
+var _react2 = _interopRequireDefault(_react);
+
+var _storybookAddons = require('@kadira/storybook-addons');
+
+var _storybookAddons2 = _interopRequireDefault(_storybookAddons);
+
+var _Usage = require('./containers/Usage');
+
+var _Usage2 = _interopRequireDefault(_Usage);
+
+var _ = require('./');
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+// register function will call addons.register to register an addon loader
+// This is executed when importing `@kadira/storybook-addon-hello/register`
+function register() {
+  // addons.register can be used to register a new addon loader function.
+  // Addon loader will receive `api` as an argument which can be used to
+  // interact with the storybook manager. We're not using it in this addon.
+  _storybookAddons2.default.register(_.ADDON_ID, function (api) {
+    // get `channel` from the addon API
+    var channel = _storybookAddons2.default.getChannel();
+    // addons.addPanel can be used to add a new panel to storybook manager
+    // The `title` field will be used as the tab title and the `render` field
+    // will be executed to render the tab content.
+    _storybookAddons2.default.addPanel(_.PANEL_ID, {
+      title: 'Usage',
+      render: function render() {
+        return _react2.default.createElement(_Usage2.default, { api: api, channel: channel });
+      }
+    });
+  });
+}

--- a/dist/preview.js
+++ b/dist/preview.js
@@ -1,0 +1,58 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.Usage = Usage;
+
+var _storybookAddons = require("@kadira/storybook-addons");
+
+var _storybookAddons2 = _interopRequireDefault(_storybookAddons);
+
+var _2 = require("./");
+
+var _lodash = require("lodash");
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function Usage(fn) {
+  var story = fn();
+  var first = "<" + story.type.name + " ";
+  _lodash2.default.toPairs(story.props).forEach(function (p) {
+    var value = void 0;
+    if (typeof p[1] === 'function') {
+      value = p[1].name ? "{" + p[1].name + "}" : '{anonymous}';
+    } else if (typeof p[1] === 'string') {
+      value = "" + JSON.stringify(p[1]);
+    } else if (_lodash2.default.isObject(p[1]) && !_lodash2.default.isArray(p[1])) {
+      value = "{" + objToString(p[1]) + "}";
+    } else {
+      value = "{" + JSON.stringify(p[1]) + "}";
+    }
+    first += " " + p[0] + "=" + value + "\n";
+  });
+  first += " />";
+  var channel = _storybookAddons2.default.getChannel();
+  channel.emit(_2.EVENT_ID, { storybook: first });
+  return fn();
+}
+
+function objToString(obj) {
+
+  var str = '{';
+  for (var p in obj) {
+    if (obj.hasOwnProperty(p)) {
+      var value = void 0;
+      if (_lodash2.default.isObject(obj[p]) && !_lodash2.default.isArray(obj[p])) {
+        value = objToString(obj[p]);
+      } else {
+        value = JSON.stringify(obj[p]);
+      }
+      str += p + ': ' + value;
+    }
+  }
+  str += '}';
+  return str;
+}

--- a/package.json
+++ b/package.json
@@ -36,6 +36,9 @@
     "react-dom": "^15.3.0",
     "shelljs": "^0.7.3"
   },
+  "dependencies": {
+    "lodash": "^4.0.0"
+  },
   "peerDependencies": {
     "@kadira/storybook-addons": "^1.3.0",
     "react": "^0.14.7 || ^15.0.0",


### PR DESCRIPTION
Fixes a couple of issues
- When trying to include this in the code base lodash 3.17 was being used but > 4.0 is required for `toPairs`.
- Commits the dist folder so that referencing this module from github works as expected.

Let me know if you want anything changed.